### PR TITLE
Add package-manager-friendly install targets and tunable variables, shared library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ tabix++: $(OBJS) main.cpp $(HTS_LIB)
 
 install: all
 	$(MKDIR) $(DESTDIR)$(PREFIX)/bin
-	$(MKDIR) $(DESTDIR)$(PREFIX)/include/tabixpp
+	$(MKDIR) $(DESTDIR)$(PREFIX)/include
 	$(MKDIR) $(DESTDIR)$(PREFIX)/lib
 	$(INSTALL) $(BIN) $(DESTDIR)$(PREFIX)/bin
-	$(INSTALL) *.hpp $(DESTDIR)$(PREFIX)/include/tabixpp
+	$(INSTALL) *.hpp $(DESTDIR)$(PREFIX)/include
 	$(INSTALL) $(LIB) $(DESTDIR)$(PREFIX)/lib
 
 install-strip: install

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install: all
 	$(MKDIR) $(DESTDIR)$(PREFIX)/lib
 	$(INSTALL) $(BIN) $(DESTDIR)$(PREFIX)/bin
 	$(INSTALL) *.hpp $(DESTDIR)$(PREFIX)/include
-	$(INSTALL) $(LIB) $(DESTDIR)$(PREFIX)/lib
+	$(INSTALL) $(LIB) $(SLIB) $(DESTDIR)$(PREFIX)/lib
 
 install-strip: install
 	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN)

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
 
 # Use ?= to allow override from the env or command-line.
 
-CC?=		gcc
-CXX?= 		g++
-CXXFLAGS?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
-INCLUDES?=	-Ihtslib
-HTS_HEADERS?=	htslib/htslib/bgzf.h htslib/htslib/tbx.h
-HTS_LIB?=	htslib/libhts.a
-LIBPATH?=	-L. -Lhtslib
+CC ?=		gcc
+CXX ?= 		g++
+CXXFLAGS ?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
+INCLUDES ?=	-Ihtslib
+HTS_HEADERS ?=	htslib/htslib/bgzf.h htslib/htslib/tbx.h
+HTS_LIB ?=	htslib/libhts.a
+LIBPATH ?=	-L. -Lhtslib
+AR ?=		ar
 
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 PROG=		tabix++

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ install: all
 	$(INSTALL) $(LIB) $(SLIB) $(DESTDIR)$(PREFIX)/lib
 
 install-strip: install
-	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN)
+	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN) $(DESTDIR)$(PREFIX)/lib/$(SLIB)
 
 cleanlocal:
 	rm -rf $(BIN) $(LIB) $(SLIB) $(OBJS) $(DESTDIR)

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ LIBPATH?=	-L. -Lhtslib
 
 DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 PROG=		tabix++
+LIB=		libtabix.a
 SUBDIRS=.
 
 .SUFFIXES:.c .o
@@ -29,13 +30,16 @@ all-recur lib-recur clean-recur cleanlocal-recur install-recur:
 		cd $$wdir; \
 	done;
 
-all:	$(PROG)
+all:	$(PROG) $(LIB)
 
 tabix.o: $(HTS_HEADERS) tabix.cpp tabix.hpp
 	$(CXX) $(CXXFLAGS) -c tabix.cpp $(INCLUDES)
 
 htslib/libhts.a:
 	cd htslib && $(MAKE) lib-static
+
+libtabix.a:
+	$(AR) rs libtabix.a tabix.o
 
 tabix++: tabix.o main.cpp $(HTS_LIB)
 	$(CXX) $(CXXFLAGS) -o $@ main.cpp tabix.o $(INCLUDES) $(LIBPATH) \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 
 CC ?=		cc
 CXX ?= 		c++
-CXXFLAGS ?=	-g -Wall -O2 -fPIC #-m64 #-arch ppc
+CXXFLAGS ?=	-g -Wall -O2 #-m64 #-arch ppc
+CXXFLAGS +=	-fPIC
 INCLUDES ?=	-Ihtslib
 HTS_HEADERS ?=	htslib/htslib/bgzf.h htslib/htslib/tbx.h
 HTS_LIB ?=	htslib/libhts.a

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ AR ?=		ar
 DFLAGS =	-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 BIN =		tabix++
 LIB =		libtabix.a
-SLIB =		libtabix.so
+SOVERSION =	1
+SLIB =		libtabix.so.$(SOVERSION)
 OBJS =		tabix.o
 SUBDIRS =	.
 
@@ -58,7 +59,7 @@ $(LIB): $(OBJS)
 	$(AR) rs $(LIB) $(OBJS)
 
 $(SLIB): $(OBJS)
-	$(CXX) -shared -Wl,-soname,$(SLIB).1 -o $(SLIB) $(OBJS)
+	$(CXX) -shared -Wl,-soname,$(SLIB) -o $(SLIB) $(OBJS)
 
 tabix++: $(OBJS) main.cpp $(HTS_LIB)
 	$(CXX) $(CXXFLAGS) -o $@ main.cpp $(OBJS) $(INCLUDES) $(LIBPATH) \
@@ -78,7 +79,7 @@ install-strip: install
 cleanlocal:
 	rm -rf $(BIN) $(LIB) $(SLIB) $(OBJS) $(DESTDIR)
 	rm -fr gmon.out *.o a.out *.dSYM $(BIN) *~ *.a tabix.aux tabix.log \
-		tabix.pdf *.class libtabix.*.dylib libtabix.so*
+		tabix.pdf *.class libtabix.*.dylib
 	cd htslib && $(MAKE) clean
 
 clean:	cleanlocal-recur

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 
-# Use ?= to allow override from the env or command-line.
+# Use ?= to allow overriding from the env or command-line, e.g.
+#
+#       make CXXFLAGS="-O3 -fPIC" install
+#
+# Package managers will override many of these variables automatically, so
+# this is aimed at making it easy to create packages (Debian packages,
+# FreeBSD ports, MacPorts, pkgsrc, etc.)
 
 CC ?=		cc
 CXX ?= 		c++

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ install-strip: install
 	$(STRIP) $(DESTDIR)$(PREFIX)/bin/$(BIN)
 
 cleanlocal:
-	rm -rf $(BIN) $(LIB) $(OBJS) $(DESTDIR)
+	rm -rf $(BIN) $(LIB) $(SLIB) $(OBJS) $(DESTDIR)
 	rm -fr gmon.out *.o a.out *.dSYM $(BIN) *~ *.a tabix.aux tabix.log \
 		tabix.pdf *.class libtabix.*.dylib libtabix.so*
 	cd htslib && $(MAKE) clean

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,10 @@ tabix++: $(OBJS) main.cpp $(HTS_LIB)
 
 install: all
 	$(MKDIR) $(DESTDIR)$(PREFIX)/bin
+	$(MKDIR) $(DESTDIR)$(PREFIX)/include/tabixpp
 	$(MKDIR) $(DESTDIR)$(PREFIX)/lib
 	$(INSTALL) $(BIN) $(DESTDIR)$(PREFIX)/bin
+	$(INSTALL) *.hpp $(DESTDIR)$(PREFIX)/include/tabixpp
 	$(INSTALL) $(LIB) $(DESTDIR)$(PREFIX)/lib
 
 install-strip: install

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ AR ?=		ar
 DFLAGS =	-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE
 BIN =		tabix++
 LIB =		libtabix.a
+SLIB =		libtabix.so
 OBJS =		tabix.o
 SUBDIRS =	.
 
@@ -38,7 +39,7 @@ all-recur lib-recur clean-recur cleanlocal-recur install-recur:
 		cd $$wdir; \
 	done;
 
-all:	$(BIN) $(LIB)
+all:	$(BIN) $(LIB) $(SLIB)
 
 tabix.o: $(HTS_HEADERS) tabix.cpp tabix.hpp
 	$(CXX) $(CXXFLAGS) -c tabix.cpp $(INCLUDES)
@@ -48,6 +49,9 @@ htslib/libhts.a:
 
 $(LIB): $(OBJS)
 	$(AR) rs $(LIB) $(OBJS)
+
+$(SLIB): $(OBJS)
+	$(CXX) -shared -Wl,-soname,$(SLIB).1 -o $(SLIB) $(OBJS)
 
 tabix++: $(OBJS) main.cpp $(HTS_LIB)
 	$(CXX) $(CXXFLAGS) -o $@ main.cpp $(OBJS) $(INCLUDES) $(LIBPATH) \


### PR DESCRIPTION
Tested both separate build and integrated build under vcflib on my end, but I recommend retesting on your platform following each pull just to be sure.
